### PR TITLE
Add Rotation Behaviour

### DIFF
--- a/Assets/Scenes/SolarSystem.unity
+++ b/Assets/Scenes/SolarSystem.unity
@@ -135,6 +135,8 @@ GameObject:
   - component: {fileID: 275834376}
   - component: {fileID: 275834375}
   - component: {fileID: 275834374}
+  - component: {fileID: 275834378}
+  - component: {fileID: 275834379}
   m_Layer: 0
   m_Name: Earth
   m_TagString: Untagged
@@ -214,10 +216,39 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_Children: []
+  m_Children:
+  - {fileID: 971394938}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &275834378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 275834373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f178c397cf5b5604daa074a72fd54cb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 275834377}
+  speed: 10
+--- !u!114 &275834379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 275834373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f178c397cf5b5604daa074a72fd54cb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 815025707}
+  speed: 40
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -322,6 +353,7 @@ GameObject:
   - component: {fileID: 815025706}
   - component: {fileID: 815025705}
   - component: {fileID: 815025704}
+  - component: {fileID: 815025708}
   m_Layer: 0
   m_Name: Sun
   m_TagString: Untagged
@@ -405,6 +437,20 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &815025708
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 815025703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f178c397cf5b5604daa074a72fd54cb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 815025707}
+  speed: 5
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -500,6 +546,8 @@ GameObject:
   - component: {fileID: 971394937}
   - component: {fileID: 971394936}
   - component: {fileID: 971394935}
+  - component: {fileID: 971394939}
+  - component: {fileID: 971394940}
   m_Layer: 0
   m_Name: Moon
   m_TagString: Untagged
@@ -576,10 +624,38 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 971394934}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.5, y: 0, z: 0}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_Father: {fileID: 275834377}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &971394939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971394934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f178c397cf5b5604daa074a72fd54cb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 971394938}
+  speed: 15
+--- !u!114 &971394940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971394934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f178c397cf5b5604daa074a72fd54cb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 275834377}
+  speed: 5


### PR DESCRIPTION
# Rotation Behaviour
To simulate the behaviour of our three planets the script `RotateAround `was added as a component
### New
- Add `RotateAround ` to Sun and set up its rotation value to rotate around itself
- Add `RotateAround ` to Earth and set up its rotation value to rotate around itself and around the Sun
- Convert the Moon as a child of Earth
- Add `RotateAround ` to Moon and set up its rotation value to rotate around itself and around the Earth